### PR TITLE
fix sensitivity setting problem.

### DIFF
--- a/src/hellodrum.cpp
+++ b/src/hellodrum.cpp
@@ -3846,9 +3846,9 @@ void HelloDrum::settingEnable()
       {
       case 0:
         sensitivity = sensitivity + UP[itemNumber];
-        if (sensitivity > 10)
+        if (sensitivity > 100)
         {
-          sensitivity = 10;
+          sensitivity = 100;
         }
         EEPROM.write(padNum * 7, sensitivity);
         break;


### PR DESCRIPTION
When using the Atmega MCU, the sensitivity could not be set higher than 10.