### PR TITLE
nameIndex reset

### DIFF
--- a/src/hellodrum.cpp
+++ b/src/hellodrum.cpp
@@ -4145,6 +4145,11 @@ void HelloDrumButton::readButtonState()
 
   ////////////////////////////// EDIT START////////////////////////////////
 
+  if (nameIndex > nameIndexMax) // Reset nameIndex
+  {
+    nameIndex = 0;
+  }
+
   if (button_set == LOW && buttonState == true && editCheck == false)
   {
     editCheck = true;


### PR DESCRIPTION
If I use the "EDIT" button before the other buttons after the program starts, nameIndex points to the wrong place. (nameIndex == nameIndexMax + 1)

I made this small change to the state before the memory optimization. (Memory optimization works fine too. I've already tested this on the ESP32 MCU.)