### PR TITLE
Name index reset 2

### DIFF
--- a/src/hellodrum.cpp
+++ b/src/hellodrum.cpp
@@ -4145,6 +4145,11 @@ void HelloDrumButton::readButtonState()
 
   ////////////////////////////// EDIT START////////////////////////////////
 
+  if (nameIndex > nameIndexMax) // Reset nameIndex
+  {
+    nameIndex = 0;
+  }
+
   if (button_set == LOW && buttonState == true && editCheck == false)
   {
     editCheck = true;


### PR DESCRIPTION
If I use the "EDIT" button before the other buttons after the program starts, nameIndex points to the wrong place. (nameIndex == nameIndexMax + 1)