### PR TITLE
fixes RP2040 build

### DIFF
--- a/src/hellodrum.cpp
+++ b/src/hellodrum.cpp
@@ -13,7 +13,10 @@
 #include "hellodrum.h"
 #include "Arduino.h"
 
-#ifdef ESP32
+#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+  // ignore for now
+  //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
+#elif defined(ESP32)
 #include "EEPROM_ESP.h"
 #else
 #include "EEPROM.h"
@@ -1352,7 +1355,12 @@ void HelloDrum::hihatControlMUX()
 
 //////////////////////////// 6. EEPROM SETTING  //////////////////////////////
 
-#ifdef ESP32
+#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+
+  // ignore for now
+  //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
+
+#elif defined(ESP32)
 
 void HelloDrum::settingEnable()
 {

--- a/src/hellodrum.cpp
+++ b/src/hellodrum.cpp
@@ -13,7 +13,7 @@
 #include "hellodrum.h"
 #include "Arduino.h"
 
-#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
   // ignore for now
   //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
 #elif defined(ESP32)
@@ -1355,7 +1355,7 @@ void HelloDrum::hihatControlMUX()
 
 //////////////////////////// 6. EEPROM SETTING  //////////////////////////////
 
-#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
 
   // ignore for now
   //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples

--- a/src/hellodrum.cpp
+++ b/src/hellodrum.cpp
@@ -1929,7 +1929,13 @@ void HelloDrum::settingName(const char *instrumentName)
   nameIndex++;
 }
 
-#ifdef ESP32
+
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
+
+  // ignore for now
+  //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
+  
+#elif defined(ESP32)
 
 void HelloDrum::loadMemory()
 {

--- a/src/hellodrum.h
+++ b/src/hellodrum.h
@@ -12,7 +12,7 @@
 
 #include "Arduino.h"
 
-#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
   // ignore for now
   //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
 #elif defined(ESP32)

--- a/src/hellodrum.h
+++ b/src/hellodrum.h
@@ -12,7 +12,10 @@
 
 #include "Arduino.h"
 
-#ifdef ESP32
+#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+  // ignore for now
+  //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
+#elif defined(ESP32)
 #include "EEPROM_ESP.h"
 #else
 #include "EEPROM.h"


### PR DESCRIPTION
This PR fixes issue #46 by disabling EEPROM / setting storage support for RP2040 boards for now. The build does not work at all / fails. The feature must be added for RP2040 boards later on.

RP2040 boards do not come with a build in EEPROM. But the Arduino EEPROM library in general does support those boards thought. They use some Flash storage to emulate the EEPROM. But it's not recommended to do it this way, because Flash storage wears out quicker than an EEPROM does.

Preferred way would be, to add an SD-Card Reader for storing the settings. For this, some generic setting handler / adapter / plugin handler would be required.