### PR TITLE
Fix Arduino Nano 33 BLE build

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino Library for piezo sensing
 paragraph=By combining with the MIDI library, you can easily create MIDI converters. By combining with Teensy audio, you can easily create synth drums.
 category=Sensors
 url=https://github.com/RyoKosaka/HelloDrum-arduino-Library
-architectures=avr,teensy,esp32
+architectures=avr,teensy,esp32,mbed_nano
 includes=hellodrum.h

--- a/src/hellodrum.cpp
+++ b/src/hellodrum.cpp
@@ -13,7 +13,10 @@
 #include "hellodrum.h"
 #include "Arduino.h"
 
-#ifdef ESP32
+#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+  // ignore for now
+  //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
+#elif defined(ESP32)
 #include "EEPROM_ESP.h"
 #else
 #include "EEPROM.h"
@@ -1352,7 +1355,12 @@ void HelloDrum::hihatControlMUX()
 
 //////////////////////////// 6. EEPROM SETTING  //////////////////////////////
 
-#ifdef ESP32
+#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+
+  // ignore for now
+  //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
+
+#elif defined(ESP32)
 
 void HelloDrum::settingEnable()
 {

--- a/src/hellodrum.cpp
+++ b/src/hellodrum.cpp
@@ -13,7 +13,7 @@
 #include "hellodrum.h"
 #include "Arduino.h"
 
-#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
   // ignore for now
   //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
 #elif defined(ESP32)
@@ -1355,7 +1355,7 @@ void HelloDrum::hihatControlMUX()
 
 //////////////////////////// 6. EEPROM SETTING  //////////////////////////////
 
-#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
 
   // ignore for now
   //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples

--- a/src/hellodrum.cpp
+++ b/src/hellodrum.cpp
@@ -1929,7 +1929,13 @@ void HelloDrum::settingName(const char *instrumentName)
   nameIndex++;
 }
 
-#ifdef ESP32
+
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
+
+  // ignore for now
+  //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
+  
+#elif defined(ESP32)
 
 void HelloDrum::loadMemory()
 {

--- a/src/hellodrum.cpp
+++ b/src/hellodrum.cpp
@@ -13,7 +13,7 @@
 #include "hellodrum.h"
 #include "Arduino.h"
 
-#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) || defined(NRF52840_XXAA) )
   // ignore for now
   //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
 #elif defined(ESP32)
@@ -1355,7 +1355,7 @@ void HelloDrum::hihatControlMUX()
 
 //////////////////////////// 6. EEPROM SETTING  //////////////////////////////
 
-#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) || defined(NRF52840_XXAA) )
 
   // ignore for now
   //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
@@ -1930,7 +1930,7 @@ void HelloDrum::settingName(const char *instrumentName)
 }
 
 
-#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) || defined(NRF52840_XXAA) )
 
   // ignore for now
   //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples

--- a/src/hellodrum.h
+++ b/src/hellodrum.h
@@ -12,7 +12,7 @@
 
 #include "Arduino.h"
 
-#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
   // ignore for now
   //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
 #elif defined(ESP32)

--- a/src/hellodrum.h
+++ b/src/hellodrum.h
@@ -12,7 +12,7 @@
 
 #include "Arduino.h"
 
-#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) )
+#if ( defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) || defined(ARDUINO_GENERIC_RP2040) || defined(NRF52840_XXAA) )
   // ignore for now
   //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
 #elif defined(ESP32)

--- a/src/hellodrum.h
+++ b/src/hellodrum.h
@@ -12,7 +12,10 @@
 
 #include "Arduino.h"
 
-#ifdef ESP32
+#if defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+  // ignore for now
+  //ToDo: Implement EEPROM handler for RP2040, see https://arduino-pico.readthedocs.io/en/latest/eeprom.html#eeprom-examples
+#elif defined(ESP32)
 #include "EEPROM_ESP.h"
 #else
 #include "EEPROM.h"


### PR DESCRIPTION
This PR allows HelloDrum to be used on Arduino Nano 33 BLE board. For now EEPROM is not used on this board (and on RP2040 boards coz it incorporates changes from SunboX). Adapters for different EEPROM libraries may be written and used in a client code during initialization (not every project needs this feature + EEPROM may be absent).